### PR TITLE
TASK: Drop support for older Neos versions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ This package allows you to configure the visibility of inspector elements, like 
 
 **CAUTION: Although this is done with policies, this is not a security feature!**
 
-If you prevent a user from editing nodes, you aditionally need to define policies with an `EditNodePropertyPrivilege` for example.
+If you prevent a user from editing nodes, you additionally need to define policies with an `EditNodePropertyPrivilege` for example.
 
 ## Installation
 
@@ -48,8 +48,8 @@ roles:
 
 #### Matcher Examples
 
-* Adress all *uriPathSegment* properties: `matcher: "${propertyName == 'uriPathSegment'}`
-* Adress all *meta* tabs of all nodeTypes `"${tabName == 'meta'}"`
+* Address all *uriPathSegment* properties: `matcher: "${propertyName == 'uriPathSegment'}`
+* Address all *meta* tabs of all nodeTypes `"${tabName == 'meta'}"`
 * Address all *title* fields of a specific type `matcher: "${nodeTypeName == 'Neos.Demo:Registration' && propertyName == 'title'}"`
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -12,11 +12,13 @@ If you prevent a user from editing nodes, you aditionally need to define policie
 
 The installation is done with composer:
 
-	composer require punktde/inspectorvisibility
-	
+```bash
+composer require punktde/inspectorvisibility
+```
+
 ## Usage
 
-The matcher can be defined using standard eel. The following properties to match for are available: 
+The matcher can be defined using standard eel. The following properties to match for are available:
 
 * nodeTypeName
 * tabName
@@ -29,7 +31,7 @@ If no policy is matching for a role, the configured visibility is used. Same, if
 
 #### Example `Policy.yaml`
 
-```
+```yaml
 privilegeTargets:
 
   'PunktDe\InspectorVisibility\Security\Authorization\Privilege\InspectorVisibilityPrivilege':

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-package",
     "name": "punktde/inspectorvisibility",
     "require": {
-        "neos/neos": "^7.0 || ^8.0 || ^9.0"
+        "neos/neos": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-package",
     "name": "punktde/inspectorvisibility",
     "require": {
-        "neos/neos": "^4.2 || ^5.0 || ^7.0 || ^8.0"
+        "neos/neos": "^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Change summary
- Dropped the support for Neos 4.x and 5.x And set the minimum requirement too Neos 7.x, and 8.x.
- Codeblocks in README

### Anything else?
- Right now its not working with Neos 9
  - The changes in the `policy` configuration do not show any effect.